### PR TITLE
Use MAX_SAFE_INTEGER instead of MAX_VALUE

### DIFF
--- a/lib/quickcheck.js
+++ b/lib/quickcheck.js
@@ -15,7 +15,7 @@ exports.arbDouble = arbDouble;
 
 function arbInt() {
   var sign = Math.random() > 0.5 ? 1 : -1;
-  return sign * Math.floor(Math.random() * Number.MAX_VALUE);
+  return sign * Math.floor(Math.random() * 9007199254740991);
 }
 
 exports.arbInt = arbInt;


### PR DESCRIPTION
The value `Number.MAX_VALUE` is usually `1.797e+308` and therefore far too large to be represented as an exact integer within JavaScript. [ES6 defines](https://developer.mozilla.org/de/docs/Web/JavaScript/Reference/Global_Objects/Number/MAX_SAFE_INTEGER) `Number.MAX_SAFE_INTEGER` as `9007199254740991`, which is the maximum exact integral number one can safe in an IEEE 754 floating point number.